### PR TITLE
fix: default pytest path to tests/

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-TEST ?=
+TEST ?= tests/
 
 .PHONY: sync test test-perf test-all clean
 


### PR DESCRIPTION
## Summary
- Set `TEST ?= tests/` in Makefile so `make test` always runs with an explicit path

## Test plan
- [x] Run `make test` and verify pytest runs against the `tests/` directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)